### PR TITLE
fix: Fetch data only if user have not opened random image generator view

### DIFF
--- a/Stellar/View/Screens/SearchDateArticleView.swift
+++ b/Stellar/View/Screens/SearchDateArticleView.swift
@@ -19,7 +19,9 @@ struct SearchDateArticleView: View {
 			}
 		}
 		.onAppear {
-			searchDateVM.generateOneArticle()
+			if searchDateVM.article == nil {
+				searchDateVM.generateOneArticle()
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add condition for check if publisher is nil, if not, do not fetch data and if it is, fetch